### PR TITLE
Cap likes display at 1000

### DIFF
--- a/src/main/java/modules/post/dao/PostDao.java
+++ b/src/main/java/modules/post/dao/PostDao.java
@@ -187,7 +187,7 @@ public class PostDao implements PostDaoInterface {
           sortingExpression = PUBLISHING_DATE;
           break;
         case "likes":
-          sortingExpression = LIKES_COUNT;
+          sortingExpression = String.format("LEAST(%s, 1000)", LIKES_COUNT);
           break;
         case "trending":
         case "trendingscore":
@@ -197,7 +197,7 @@ public class PostDao implements PostDaoInterface {
           break;
       }
     }
-    return sortingExpression + " " + order;
+    return String.format("%s %s, %s DESC", sortingExpression, order, ID);
   }
 
   private void populateLikedBy(List<Post> posts) {

--- a/src/main/java/modules/post/dao/PostDao.java
+++ b/src/main/java/modules/post/dao/PostDao.java
@@ -32,8 +32,8 @@ public class PostDao implements PostDaoInterface {
   private static final String DEEP_SELECT =
       String.format(
           "SELECT p.*, u.%s, u.%s, u.%s, u.%s, w.%1$s as wall_%1$s, w.%2$s as wall_%2$s, w.%3$s as wall_%3$s, w.%4$s as wall_%4$s,"
-              // Rank posts by:  likes / (1+days)^gravity
-              + "(likes_count / POWER(1 + EXTRACT(epoch from AGE(NOW(), p.pub_date)) / 86400, 2)) as score",
+              // Rank posts by:  likes / (1+days)^gravity, capped at 1000 likes
+              + "(LEAST(likes_count, 1000) / POWER(1 + EXTRACT(epoch from AGE(NOW(), p.pub_date)) / 86400, 2)) as score",
           UserDao.ID, UserDao.USERNAME, UserDao.HOBBIES, UserDao.ABOUT);
 
   @Autowired
@@ -225,7 +225,7 @@ public class PostDao implements PostDaoInterface {
         post.setId(rs.getInt(ID));
         post.setMessage(rs.getString(MESSAGE));
         post.setPublishingDate(rs.getTimestamp(PUBLISHING_DATE));
-        post.setLikesCount(rs.getInt(LIKES_COUNT));
+        post.setLikesCount(Math.min(rs.getInt(LIKES_COUNT), 1000));
         post.setTrendingScore(rs.getDouble(SCORE));
 
         post.setUser(getUserFromResult(rs, ""));

--- a/src/main/resources/templates/posts/post.ftl
+++ b/src/main/resources/templates/posts/post.ftl
@@ -27,7 +27,7 @@
 							<button class="button action-button colored" type="submit" title="Gefällt mir nicht mehr">
 								<i class="icon-current fas fa-heart"></i>
 								<i class="icon-action fas fa-heart-broken"></i>
-								<span>${post.likesCount}</span>
+								<span>${post.likesCount}${(post.likesCount >= 1000)?then("+","")}</span>
 							</button>
 						</form>
 					<#else>
@@ -36,15 +36,15 @@
 							<button class="button action-button colored" type="submit" title="Gefällt mir">
 								<i class="icon-current far fa-heart"></i>
 								<i class="icon-action fas fa-heart"></i>
-								<span>${post.likesCount}</span>
+								<span>${post.likesCount}${(post.likesCount >= 1000)?then("+","")}</span>
 							</button>
 						</form>
 					</#if>
 				<#else>
-					<span class="likes-count"><i class="far fa-heart"></i><span>${post.likesCount}</span></span>
+					<span class="likes-count"><i class="far fa-heart"></i><span>${post.likesCount}${(post.likesCount >= 1000)?then("+","")}</span></span>
 				</#if>
 				<span class="likes">
-					<#if post.likesCount gt likesShown><span class="overlapping"><span class="profile-pic small" data-tooltip="${post.likesCount - likesShown} weitere">...</span></span></#if>
+					<#if post.likesCount gt likesShown><span class="overlapping"><span class="profile-pic small" data-tooltip="${post.likesCount - likesShown}${(post.likesCount >= 1000)?then("+","")} weitere">...</span></span></#if>
 					<#if post.likesCount gt 0>
 						<#list post.getRecentLikes()[(likesShown-1)..0] as likingUser>
 							 <a class="overlapping" data-tooltip="${likingUser.username}" href="/user/profile/${likingUser.username?url}"><img class="profile-pic small" alt="${likingUser.username} Like" src="${likingUser.image}" style="vertical-align:middle"></a>


### PR DESCRIPTION
As discussed in #70 having unbounded likes might not be sustainable for the server in the future, so this PR removes incentives to go for more than 1000 likes.

This is basically only a visual change. It still is possible to like the posts after 1000 likes, but after that it won't affect the sorting in trending, mostlikes etc. The only thing is you will see your profile picture when you like:

Not liked: 
![grafik](https://user-images.githubusercontent.com/11499926/183314576-25eeb6ba-11c7-422c-98bc-6b2ae1718880.png)
Liked:
![grafik](https://user-images.githubusercontent.com/11499926/183314504-7c33c28e-0e85-4421-b05e-b4d1f2dcc227.png)
