### PR TITLE
Enable CORS for all interfaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<embedded-postgres.version>2.0.7</embedded-postgres.version>
 		<jbcrypt.version>0.4</jbcrypt.version>
 		<sl4j.version>2.0.7</sl4j.version>
-		<git-code-format-maven-plugin.version>3.4</git-code-format-maven-plugin.version>
+		<git-code-format-maven-plugin.version>5.3</git-code-format-maven-plugin.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -290,6 +290,13 @@
 				<configuration>
 					<skip>${skipTests}</skip>
 				</configuration>
+				<dependencies>
+					<dependency>
+					    <groupId>com.cosium.code</groupId>
+					    <artifactId>google-java-format</artifactId>
+					    <version>5.3</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>com.github.eirslett</groupId>

--- a/src/main/java/config/Router.java
+++ b/src/main/java/config/Router.java
@@ -46,6 +46,26 @@ public class Router {
   public void setupRoutes() {
     app.routes(
         () -> {
+          // Activate CORS
+          app.options(
+              "/*",
+              ctx -> {
+                String accessControlRequestHeaders = ctx.header("Access-Control-Request-Headers");
+                if (accessControlRequestHeaders != null) {
+                  ctx.header("Access-Control-Allow-Headers", accessControlRequestHeaders);
+                }
+
+                String accessControlRequestMethod = ctx.header("Access-Control-Request-Method");
+                if (accessControlRequestMethod != null) {
+                  ctx.header("Access-Control-Allow-Methods", accessControlRequestMethod);
+                }
+              });
+          before(
+              "/*",
+              ctx -> {
+                ctx.header("Access-Control-Allow-Origin", "*");
+                ctx.header("Access-Control-Allow-Headers", "*");
+              });
           get("/registrieren", userController::register);
           post("/registrieren", userController::register);
 
@@ -78,28 +98,6 @@ public class Router {
                 get("", ctx -> ctx.redirect("/docs/index.html"));
                 before("/*", ctx -> logger.debug("Received api call to path {}", ctx.path()));
 
-                // Activate CORS
-                app.options(
-                    "/*",
-                    ctx -> {
-                      String accessControlRequestHeaders =
-                          ctx.header("Access-Control-Request-Headers");
-                      if (accessControlRequestHeaders != null) {
-                        ctx.header("Access-Control-Allow-Headers", accessControlRequestHeaders);
-                      }
-
-                      String accessControlRequestMethod =
-                          ctx.header("Access-Control-Request-Method");
-                      if (accessControlRequestMethod != null) {
-                        ctx.header("Access-Control-Allow-Methods", accessControlRequestMethod);
-                      }
-                    });
-                before(
-                    "/*",
-                    ctx -> {
-                      ctx.header("Access-Control-Allow-Origin", "*");
-                      ctx.header("Access-Control-Allow-Headers", "*");
-                    });
                 before("/*", this::checkCorrectRequestType);
                 before(
                     "/*",


### PR DESCRIPTION
To allow usage of the application within browsers, e.g. the OnlineIDE or JavaScript clients, CORS is enabled on the API, however some of the web interfaces are needed as well for some bots, so this PR enables it globally.